### PR TITLE
Fix HTML: move <th> inside <tr> to prevent hydration warning

### DIFF
--- a/src/components/MessageBox.vue
+++ b/src/components/MessageBox.vue
@@ -61,8 +61,7 @@ watch(elementContent, () => {
 				</div>
 			</div>
 			<div v-if="why" class="divider divider-horizontal m-0 w-px before:bg-base-200 after:bg-base-200" />
-			<button v-if="why" class="btn btn-circle btn-primary btn-xs mx-2"
-				@click="whyPanel?.togglePanel()">
+			<button v-if="why" class="btn btn-circle btn-primary btn-xs mx-2" @click="whyPanel?.togglePanel()">
 				<p class="text-base">
 					?
 				</p>
@@ -73,9 +72,11 @@ watch(elementContent, () => {
 				<div class="overflow-x-auto rounded-md border-2 border-neutral">
 					<table class="table table-zebra table-sm text-center">
 						<thead class="bg-base-100 text-neutral">
-							<th>🧰 Tool</th>
-							<th>⌨️ Input</th>
-							<th>💬 Output</th>
+							<tr>
+								<th>🧰 Tool</th>
+								<th>⌨️ Input</th>
+								<th>💬 Output</th>
+							</tr>
 						</thead>
 						<tbody v-if="why.intermediate_steps?.length > 0">
 							<tr v-for="data in why.intermediate_steps" :key="data[0]">


### PR DESCRIPTION
This PR fixes a warning from Vite about invalid HTML structure:

<th> cannot be child of <thead>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.

Moved the <th> elements inside a <tr> within <thead>, as per HTML spec.  
This prevents potential hydration issues in SSR and ensures future compatibility.

No other functional changes.
